### PR TITLE
Fetch and display subject set names instead of IDs

### DIFF
--- a/src/pages/UploadPage.js
+++ b/src/pages/UploadPage.js
@@ -47,9 +47,18 @@ export default class UploadPage extends React.Component {
   }
 
   updateSelectedProject(el) {
+    var projectKey = el.target.value
     this.setState({
-      projectKey: el.target.value,
+      projectKey: projectKey,
       subjectSetKey: null
+    })
+    prnClient.get('subject-sets', { project_id: this.state.projects[projectKey].id })
+    .then(subjectSets => {
+      this.setState({ subjectSets })
+    })
+    .catch(err => {
+      console.error('Failed to fetch/store subject sets for project. Error was: %s', err)
+      alert('Error fetching subject sets')
     })
   }
 
@@ -83,15 +92,11 @@ export default class UploadPage extends React.Component {
     var subjectSetKey = this.state.subjectSetKey
     var projects = this.state.projects
 
-    if(projects && projectKey) {
-      var subjectSets = projects[projectKey].links.subject_sets
-      console.log('SUBJECT_SETS = ', subjectSets);
-    }
 
     /* Generate subject set options, or null if none available */
-    var subjectSetOptions = subjectSets ?
-      subjectSets.map(function(subjectSetId, key){
-        return(<option key={key} value={key}>{subjectSetId}</option>)
+    var subjectSetOptions = this.state.subjectSets ?
+      this.state.subjectSets.map(function(subjectSet, key){
+        return(<option key={key} value={key}>{subjectSet.display_name}</option>)
       }) : null
 
     var value = subjectSetKey ? subjectSetKey : 'default'


### PR DESCRIPTION
Shows subject set names in dropdown on upload page instead of IDs. Dependent on [zooniverse/planetary-response-network#48](https://github.com/zooniverse/planetary-response-network/pull/48)
